### PR TITLE
Add pinboardtoken option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Plugin to add commands to vimperator that will save bookmarks to pinboard.in.
 
 ## Usage
 
+    :set pinboardtoken="username:token"
+
     :pin[board] [-s] [-r] [-t <title>] [-d <description>] [space separated tags]...
         -s Bookmark as public.  Default is private.
         -r Bookmark as read.  Default is unread.

--- a/pinboard.js
+++ b/pinboard.js
@@ -1,6 +1,12 @@
 (function() {
 
   function buildURL(url, queries) {
+    // see https://blog.pinboard.in/2012/07/api_authentication_tokens/
+    var token = options.get('pinboardtoken').get();
+    if (token != null && token != '') {
+      queries.push(['auth_token', token]);
+    }
+
     var result = [url];
     for (var i = 0; i < queries.length; i++)
       if (queries[i][1])
@@ -22,6 +28,10 @@
     } catch (e) {
       liberator.log('Error opening ' + url + ': ' + e, 1);
     }
+  }
+
+  if (options.get('pinboardtoken') == null) {
+    options.add(['pinboardtoken'], 'Pinboard.in token (username:token)', 'string', '');
   }
 
   commands.addUserCommand(['pin[board]'], 'Bookmark page at pinboard.in', function(args) {


### PR DESCRIPTION
Put Pinboard token in query params if set. 

This will avoid using basic HTTP auth.
